### PR TITLE
envを読み込まないように修正

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"io/ioutil"
-	"log"
 
 	yaml "gopkg.in/yaml.v2"
 )
@@ -18,12 +17,12 @@ type Configs struct {
 func ApplyConfig() Configs {
 	configs := Configs{}
 
-	e, err := applyEnv()
-	if err != nil {
-		log.Fatal(err)
-	}
+	// e, err := applyEnv()
+	// if err != nil {
+	// 	log.Fatal(err)
+	// }
 
-	configs.Env = &e
+	// configs.Env = &e
 
 	return configs
 }


### PR DESCRIPTION
# 概要
GAE上でenvの読み込み部分でエラーが起きている。
そのため一時的にenvの読み込み部分をコメントアウトしてGAEで動作するようにする。